### PR TITLE
fix(hyperspace): ensure float precision in flare calculations

### DIFF
--- a/src/hyperspace/flare.cpp
+++ b/src/hyperspace/flare.cpp
@@ -189,7 +189,7 @@ void flare(double *pos, float red, float green, float blue, float alpha){
 		&winx, &winy, &winz);
 	x = (float(winx) / float(xsize)) * aspectRatio;
 	y = float(winy) / float(ysize);
-	float diff[3] = {pos[0] - camPos[0], pos[1] - camPos[1], pos[2] - camPos[2]};
+	float diff[3] = {float(pos[0] - camPos[0]), float(pos[1] - camPos[1]), float(pos[2] - camPos[2])};
 	if(diff[0] * billboardMat[8] + diff[1] * billboardMat[9] + diff[2] * billboardMat[10] > 0.0f)
 		return;
 

--- a/src/hyperspace/hyperspace.cpp
+++ b/src/hyperspace/hyperspace.cpp
@@ -364,10 +364,10 @@ void draw(){
 
 	// draw sun with lens flare
 	glDisable(GL_FOG);
-	double flarepos[3] = {0.0f, 2.0f, 0.0f};
+	double flarepos[3] = {0.0, 2.0, 0.0};
 	glBindTexture(GL_TEXTURE_2D, flaretex[0]);
 	sunStar->draw(camPos);
-	float diff[3] = {flarepos[0] - camPos[0], flarepos[1] - camPos[1], flarepos[2] - camPos[2]};
+	float diff[3] = {float(flarepos[0] - camPos[0]), float(flarepos[1] - camPos[1]), float(flarepos[2] - camPos[2])};
 	float alpha = 0.5f - 0.005f * sqrtf(diff[0] * diff[0] + diff[1] * diff[1] + diff[2] * diff[2]);
 	if(alpha > 0.0f)
 		flare(flarepos, 1.0f, 1.0f, 1.0f, alpha);


### PR DESCRIPTION
This pull request makes minor improvements to type consistency in the calculation of vector differences for lens flare rendering in the hyperspace module. The changes ensure that intermediate values are explicitly cast to `float`, which can help prevent potential type-related issues and improve code clarity.

Type consistency improvements:

* Explicitly cast the results of vector subtraction to `float` in the computation of the `diff` array in both the `flare` function (`src/hyperspace/flare.cpp`) and the `draw` function (`src/hyperspace/hyperspace.cpp`). [[1]](diffhunk://#diff-22f54e009cde220628c1b96238d5b377672591c7b57cac5ce1686ac5c36d3917L192-R192) [[2]](diffhunk://#diff-97730a08459018d3a861ddd21a31e6e2cffe917064c838f59addeed1b3c1659fL367-R370)
* Standardized the initialization of the `flarepos` array to use `double` literals for consistency in `src/hyperspace/hyperspace.cpp`.