### PR TITLE
fix(euphoria): replace powf with bit-shift and clamp registry input

### DIFF
--- a/src/euphoria/euphoria.cpp
+++ b/src/euphoria/euphoria.cpp
@@ -530,7 +530,7 @@ void initSaver(HWND hwnd){
 		feedbacktexsize = 1 << dFeedbacksize;
 		// Feedback texture can't be bigger than the window using glCopyTexSubImage2D.
 		// (This wouldn't be a limitation if we used FBOs.)
-		while((feedbacktexsize > viewport[2] || feedbacktexsize > viewport[3]) && dFeedbacksize > 0){
+		while((feedbacktexsize > viewport[2] || feedbacktexsize > viewport[3]) && dFeedbacksize > FEEDBACKSIZE_MIN){
 			dFeedbacksize -= 1;
 			feedbacktexsize = 1 << dFeedbacksize;
 		}
@@ -850,13 +850,13 @@ void initControls(HWND hdlg){
 	SendDlgItemMessage(hdlg, FEEDBACKSPEEDTEXT, WM_SETTEXT, 0, LPARAM(cval));
 
 	SendDlgItemMessage(hdlg, FEEDBACKSIZE, TBM_SETRANGE, 0, LPARAM(MAKELONG(DWORD(FEEDBACKSIZE_MIN), DWORD(FEEDBACKSIZE_MAX))));
-	SendDlgItemMessage(hdlg, FEEDBACKSIZE, TBM_SETPOS, 1, LPARAM(dFeedbacksize));
-	SendDlgItemMessage(hdlg, FEEDBACKSIZE, TBM_SETLINESIZE, 0, LPARAM(1));
-	SendDlgItemMessage(hdlg, FEEDBACKSIZE, TBM_SETPAGESIZE, 0, LPARAM(1));
 	if(dFeedbacksize < FEEDBACKSIZE_MIN)
 		dFeedbacksize = FEEDBACKSIZE_MIN;
 	else if(dFeedbacksize > FEEDBACKSIZE_MAX)
 		dFeedbacksize = FEEDBACKSIZE_MAX;
+	SendDlgItemMessage(hdlg, FEEDBACKSIZE, TBM_SETPOS, 1, LPARAM(dFeedbacksize));
+	SendDlgItemMessage(hdlg, FEEDBACKSIZE, TBM_SETLINESIZE, 0, LPARAM(1));
+	SendDlgItemMessage(hdlg, FEEDBACKSIZE, TBM_SETPAGESIZE, 0, LPARAM(1));
 	sprintf_s(cval, "%d", 1 << dFeedbacksize);
 	SendDlgItemMessage(hdlg, FEEDBACKSIZETEXT, WM_SETTEXT, 0, LPARAM(cval));
 

--- a/src/euphoria/euphoria.cpp
+++ b/src/euphoria/euphoria.cpp
@@ -534,7 +534,7 @@ void initSaver(HWND hwnd){
 			dFeedbacksize -= 1;
 			feedbacktexsize = 1 << dFeedbacksize;
 		}
-		// Disable feedback if viewport is too small for even a 1x1 texture
+		// Disable feedback if viewport is too small for even a 2x2 texture
 		if(feedbacktexsize > viewport[2] || feedbacktexsize > viewport[3]){
 			dFeedback = 0;
 		}

--- a/src/euphoria/euphoria.cpp
+++ b/src/euphoria/euphoria.cpp
@@ -521,12 +521,12 @@ void initSaver(HWND hwnd){
 	}
 
 	if(dFeedback){
-		feedbacktexsize = int(powf(2, dFeedbacksize));
+		feedbacktexsize = int(powf(2.0f, float(dFeedbacksize)));
 		// Feedback texture can't be bigger than the window using glCopyTexSubImage2D.
 		// (This wouldn't be a limitation if we used FBOs.)
 		while(feedbacktexsize > viewport[2] || feedbacktexsize > viewport[3]){
 			dFeedbacksize -= 1;
-			feedbacktexsize = int(powf(2, dFeedbacksize));
+			feedbacktexsize = int(powf(2.0f, float(dFeedbacksize)));
 		}
 
 		// feedback texture setup
@@ -842,7 +842,7 @@ void initControls(HWND hdlg){
 	SendDlgItemMessage(hdlg, FEEDBACKSIZE, TBM_SETPOS, 1, LPARAM(dFeedbacksize));
 	SendDlgItemMessage(hdlg, FEEDBACKSIZE, TBM_SETLINESIZE, 0, LPARAM(1));
 	SendDlgItemMessage(hdlg, FEEDBACKSIZE, TBM_SETPAGESIZE, 0, LPARAM(1));
-	sprintf_s(cval, "%d", int(powf(2, dFeedbacksize)));
+	sprintf_s(cval, "%d", int(powf(2.0f, float(dFeedbacksize))));
 	SendDlgItemMessage(hdlg, FEEDBACKSIZETEXT, WM_SETTEXT, 0, LPARAM(cval));
 
 	SendDlgItemMessage(hdlg, TEXTURE, CB_DELETESTRING, WPARAM(4), 0);
@@ -944,7 +944,7 @@ BOOL screenSaverConfigureDialog(HWND hdlg, UINT msg, WPARAM wpm, LPARAM lpm){
 		}
 		if(HWND(lpm) == GetDlgItem(hdlg, FEEDBACKSIZE)){
 			ival = SendDlgItemMessage(hdlg, FEEDBACKSIZE, TBM_GETPOS, 0, 0);
-			sprintf_s(cval, "%d", int(powf(2, ival)));
+			sprintf_s(cval, "%d", int(powf(2.0f, float(ival))));
 			SendDlgItemMessage(hdlg, FEEDBACKSIZETEXT, WM_SETTEXT, 0, LPARAM(cval));
 		}
 		if(HWND(lpm) == GetDlgItem(hdlg, FRAMERATELIMIT))

--- a/src/euphoria/euphoria.cpp
+++ b/src/euphoria/euphoria.cpp
@@ -521,12 +521,16 @@ void initSaver(HWND hwnd){
 	}
 
 	if(dFeedback){
-		feedbacktexsize = int(powf(2.0f, float(dFeedbacksize)));
+		if(dFeedbacksize < 1)
+			dFeedbacksize = 1;
+		else if(dFeedbacksize > 10)
+			dFeedbacksize = 10;
+		feedbacktexsize = 1 << dFeedbacksize;
 		// Feedback texture can't be bigger than the window using glCopyTexSubImage2D.
 		// (This wouldn't be a limitation if we used FBOs.)
 		while(feedbacktexsize > viewport[2] || feedbacktexsize > viewport[3]){
 			dFeedbacksize -= 1;
-			feedbacktexsize = int(powf(2.0f, float(dFeedbacksize)));
+			feedbacktexsize = 1 << dFeedbacksize;
 		}
 
 		// feedback texture setup
@@ -842,7 +846,7 @@ void initControls(HWND hdlg){
 	SendDlgItemMessage(hdlg, FEEDBACKSIZE, TBM_SETPOS, 1, LPARAM(dFeedbacksize));
 	SendDlgItemMessage(hdlg, FEEDBACKSIZE, TBM_SETLINESIZE, 0, LPARAM(1));
 	SendDlgItemMessage(hdlg, FEEDBACKSIZE, TBM_SETPAGESIZE, 0, LPARAM(1));
-	sprintf_s(cval, "%d", int(powf(2.0f, float(dFeedbacksize))));
+	sprintf_s(cval, "%d", 1 << dFeedbacksize);
 	SendDlgItemMessage(hdlg, FEEDBACKSIZETEXT, WM_SETTEXT, 0, LPARAM(cval));
 
 	SendDlgItemMessage(hdlg, TEXTURE, CB_DELETESTRING, WPARAM(4), 0);
@@ -944,7 +948,7 @@ BOOL screenSaverConfigureDialog(HWND hdlg, UINT msg, WPARAM wpm, LPARAM lpm){
 		}
 		if(HWND(lpm) == GetDlgItem(hdlg, FEEDBACKSIZE)){
 			ival = SendDlgItemMessage(hdlg, FEEDBACKSIZE, TBM_GETPOS, 0, 0);
-			sprintf_s(cval, "%d", int(powf(2.0f, float(ival))));
+			sprintf_s(cval, "%d", 1 << ival);
 			SendDlgItemMessage(hdlg, FEEDBACKSIZETEXT, WM_SETTEXT, 0, LPARAM(cval));
 		}
 		if(HWND(lpm) == GetDlgItem(hdlg, FRAMERATELIMIT))

--- a/src/euphoria/euphoria.cpp
+++ b/src/euphoria/euphoria.cpp
@@ -528,7 +528,7 @@ void initSaver(HWND hwnd){
 		feedbacktexsize = 1 << dFeedbacksize;
 		// Feedback texture can't be bigger than the window using glCopyTexSubImage2D.
 		// (This wouldn't be a limitation if we used FBOs.)
-		while(feedbacktexsize > viewport[2] || feedbacktexsize > viewport[3]){
+		while((feedbacktexsize > viewport[2] || feedbacktexsize > viewport[3]) && dFeedbacksize > 0){
 			dFeedbacksize -= 1;
 			feedbacktexsize = 1 << dFeedbacksize;
 		}
@@ -846,6 +846,10 @@ void initControls(HWND hdlg){
 	SendDlgItemMessage(hdlg, FEEDBACKSIZE, TBM_SETPOS, 1, LPARAM(dFeedbacksize));
 	SendDlgItemMessage(hdlg, FEEDBACKSIZE, TBM_SETLINESIZE, 0, LPARAM(1));
 	SendDlgItemMessage(hdlg, FEEDBACKSIZE, TBM_SETPAGESIZE, 0, LPARAM(1));
+	if(dFeedbacksize < 1)
+		dFeedbacksize = 1;
+	else if(dFeedbacksize > 10)
+		dFeedbacksize = 10;
 	sprintf_s(cval, "%d", 1 << dFeedbacksize);
 	SendDlgItemMessage(hdlg, FEEDBACKSIZETEXT, WM_SETTEXT, 0, LPARAM(cval));
 

--- a/src/euphoria/euphoria.cpp
+++ b/src/euphoria/euphoria.cpp
@@ -44,6 +44,8 @@
 
 #define NUMCONSTS 9
 #define PIx2 6.28318530718f
+#define FEEDBACKSIZE_MIN 1
+#define FEEDBACKSIZE_MAX 10
 
 
 class wisp;
@@ -521,10 +523,10 @@ void initSaver(HWND hwnd){
 	}
 
 	if(dFeedback){
-		if(dFeedbacksize < 1)
-			dFeedbacksize = 1;
-		else if(dFeedbacksize > 10)
-			dFeedbacksize = 10;
+		if(dFeedbacksize < FEEDBACKSIZE_MIN)
+			dFeedbacksize = FEEDBACKSIZE_MIN;
+		else if(dFeedbacksize > FEEDBACKSIZE_MAX)
+			dFeedbacksize = FEEDBACKSIZE_MAX;
 		feedbacktexsize = 1 << dFeedbacksize;
 		// Feedback texture can't be bigger than the window using glCopyTexSubImage2D.
 		// (This wouldn't be a limitation if we used FBOs.)
@@ -532,25 +534,30 @@ void initSaver(HWND hwnd){
 			dFeedbacksize -= 1;
 			feedbacktexsize = 1 << dFeedbacksize;
 		}
+		// Disable feedback if viewport is too small for even a 1x1 texture
+		if(feedbacktexsize > viewport[2] || feedbacktexsize > viewport[3]){
+			dFeedback = 0;
+		}
+		else{
+			// feedback texture setup
+			glEnable(GL_TEXTURE_2D);
+			glGenTextures(1, &feedbacktex);
+			glBindTexture(GL_TEXTURE_2D, feedbacktex);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
+			glTexImage2D(GL_TEXTURE_2D, 0, 3, feedbacktexsize, feedbacktexsize, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
 
-		// feedback texture setup
-		glEnable(GL_TEXTURE_2D);
-		glGenTextures(1, &feedbacktex);
-		glBindTexture(GL_TEXTURE_2D, feedbacktex);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
-		glTexImage2D(GL_TEXTURE_2D, 0, 3, feedbacktexsize, feedbacktexsize, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
-
-		// feedback velocity variable setup
-		fv[0] = float(dFeedbackspeed) * (rsRandf(0.025f) + 0.025f);
-		fv[1] = float(dFeedbackspeed) * (rsRandf(0.05f) + 0.05f);
-		fv[2] = float(dFeedbackspeed) * (rsRandf(0.05f) + 0.05f);
-		fv[3] = float(dFeedbackspeed) * (rsRandf(0.1f) + 0.1f);
-		lv[0] = float(dFeedbackspeed) * (rsRandf(0.0025f) + 0.0025f);
-		lv[1] = float(dFeedbackspeed) * (rsRandf(0.0025f) + 0.0025f);
-		lv[2] = float(dFeedbackspeed) * (rsRandf(0.0025f) + 0.0025f);
+			// feedback velocity variable setup
+			fv[0] = float(dFeedbackspeed) * (rsRandf(0.025f) + 0.025f);
+			fv[1] = float(dFeedbackspeed) * (rsRandf(0.05f) + 0.05f);
+			fv[2] = float(dFeedbackspeed) * (rsRandf(0.05f) + 0.05f);
+			fv[3] = float(dFeedbackspeed) * (rsRandf(0.1f) + 0.1f);
+			lv[0] = float(dFeedbackspeed) * (rsRandf(0.0025f) + 0.0025f);
+			lv[1] = float(dFeedbackspeed) * (rsRandf(0.0025f) + 0.0025f);
+			lv[2] = float(dFeedbackspeed) * (rsRandf(0.0025f) + 0.0025f);
+		}
 	}
 
 	// Initialize wisps
@@ -842,14 +849,14 @@ void initControls(HWND hdlg){
 	sprintf_s(cval, "%d", dFeedbackspeed);
 	SendDlgItemMessage(hdlg, FEEDBACKSPEEDTEXT, WM_SETTEXT, 0, LPARAM(cval));
 
-	SendDlgItemMessage(hdlg, FEEDBACKSIZE, TBM_SETRANGE, 0, LPARAM(MAKELONG(DWORD(1), DWORD(10))));
+	SendDlgItemMessage(hdlg, FEEDBACKSIZE, TBM_SETRANGE, 0, LPARAM(MAKELONG(DWORD(FEEDBACKSIZE_MIN), DWORD(FEEDBACKSIZE_MAX))));
 	SendDlgItemMessage(hdlg, FEEDBACKSIZE, TBM_SETPOS, 1, LPARAM(dFeedbacksize));
 	SendDlgItemMessage(hdlg, FEEDBACKSIZE, TBM_SETLINESIZE, 0, LPARAM(1));
 	SendDlgItemMessage(hdlg, FEEDBACKSIZE, TBM_SETPAGESIZE, 0, LPARAM(1));
-	if(dFeedbacksize < 1)
-		dFeedbacksize = 1;
-	else if(dFeedbacksize > 10)
-		dFeedbacksize = 10;
+	if(dFeedbacksize < FEEDBACKSIZE_MIN)
+		dFeedbacksize = FEEDBACKSIZE_MIN;
+	else if(dFeedbacksize > FEEDBACKSIZE_MAX)
+		dFeedbacksize = FEEDBACKSIZE_MAX;
 	sprintf_s(cval, "%d", 1 << dFeedbacksize);
 	SendDlgItemMessage(hdlg, FEEDBACKSIZETEXT, WM_SETTEXT, 0, LPARAM(cval));
 


### PR DESCRIPTION
Replace powf(2, n) with exact integer bit-shift (1 << n) for feedback texture size computation in euphoria.cpp, and add input validation for the registry-loaded dFeedbacksize variable.

Changes:
- Replace all powf(2, dFeedbacksize) / powf(2, ival) calls with 1 << dFeedbacksize / 1 << ival for exact integer power-of-two computation, eliminating float rounding/truncation risk.
- Clamp dFeedbacksize to valid slider range [1, 10] in initSaver() and initControls() before use as a shift count, preventing undefined behavior from out-of-range registry values.
- Add lower bound guard (dFeedbacksize > 0) to the feedback texture resize loop, preventing undefined behavior from shifting by a negative count when the viewport is very small.