### PR TITLE
fix(build): add /LTCG to linker settings for projects using /GL

### DIFF
--- a/src/euphoria/euphoria.vcxproj
+++ b/src/euphoria/euphoria.vcxproj
@@ -103,6 +103,7 @@
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention />
       <TargetMachine>MachineX86</TargetMachine>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
     <PostBuildEvent>
       <Command>powershell Copy-Item $(OutDir)$(TargetName)$(TargetExt) $(OutDir)$(TargetName).scr -Force</Command>

--- a/src/fieldlines/fieldlines.vcxproj
+++ b/src/fieldlines/fieldlines.vcxproj
@@ -104,6 +104,7 @@
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention />
       <TargetMachine>MachineX86</TargetMachine>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
     <PostBuildEvent>
       <Command>powershell Copy-Item $(OutDir)$(TargetName)$(TargetExt) $(OutDir)$(TargetName).scr -Force</Command>

--- a/src/flux/flux.vcxproj
+++ b/src/flux/flux.vcxproj
@@ -103,6 +103,7 @@
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention />
       <TargetMachine>MachineX86</TargetMachine>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
     <PostBuildEvent>
       <Command>powershell Copy-Item $(OutDir)$(TargetName)$(TargetExt) $(OutDir)$(TargetName).scr -Force</Command>

--- a/src/implicitDemo/implicitDemo.vcxproj
+++ b/src/implicitDemo/implicitDemo.vcxproj
@@ -101,6 +101,7 @@
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention />
       <TargetMachine>MachineX86</TargetMachine>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
This pull request updates the build configuration for several Visual Studio C++ project files to enable link-time code generation. This optimization can improve runtime performance by allowing the linker to perform additional optimizations across the entire program.

Build optimization changes:

* Enabled link-time code generation by adding `<LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>` to the following project files:
  - `src/euphoria/euphoria.vcxproj`
  - `src/fieldlines/fieldlines.vcxproj`
  - `src/flux/flux.vcxproj`
  - `src/implicitDemo/implicitDemo.vcxproj`