### PR TITLE
hyperspace: disable vsync to allow frame rate limiter to work

### DIFF
--- a/src/hyperspace/hyperspace.cpp
+++ b/src/hyperspace/hyperspace.cpp
@@ -499,6 +499,13 @@ void initSaver(HWND hwnd){
 	GetClientRect(hwnd, &rect);
 	wglMakeCurrent(hdc, hglrc);
 
+	// Disable vsync so frame rate is not capped at monitor refresh rate
+	typedef BOOL (APIENTRY *PFNWGLSWAPINTERVALEXTPROC)(int);
+	PFNWGLSWAPINTERVALEXTPROC wglSwapIntervalEXT =
+		(PFNWGLSWAPINTERVALEXTPROC)wglGetProcAddress("wglSwapIntervalEXT");
+	if(wglSwapIntervalEXT)
+		wglSwapIntervalEXT(0);
+
 	// setup viewport
 	//viewport[0] = rect.left;
 	//viewport[1] = rect.top;

--- a/src/hyperspace/hyperspace.cpp
+++ b/src/hyperspace/hyperspace.cpp
@@ -448,6 +448,7 @@ void setDefaults(){
 	dUseTunnels = 1;
 	dUseGoo = 1;
 	dShaders = 1;
+	dFrameRateLimit = 0;
 }
 
 


### PR DESCRIPTION
## Summary
Disables vsync in the Hyperspace screensaver so the Frame Rate Limit slider actually controls the maximum FPS.

## Problem
`wglSwapLayerBuffers` respects vsync, which caps the frame rate at the monitor refresh rate (typically 60 Hz) regardless of the Frame Rate Limit setting. Setting the limit to 0 (unlimited) still results in ~60 FPS.

## Fix
Adds `wglSwapIntervalEXT(0)` immediately after `wglMakeCurrent` in `initSaver()`. This disables vsync so the screensaver runs at the configured frame rate limit, or as fast as possible when set to 0.

## Testing
Tested on Windows 11 with an RTX 5070. Before: always ~60 FPS. After: 300+ FPS at default settings with limit=0.